### PR TITLE
Fix code attempting to set an enum to null

### DIFF
--- a/Assets/Plugins/Appboy/models/Cards/Card.cs
+++ b/Assets/Plugins/Appboy/models/Cards/Card.cs
@@ -47,10 +47,13 @@ namespace Appboy.Models.Cards {
           Categories.Add(CardCategory.NO_CATEGORY);
         } else {
           for (int i = 0; i < jsonArray.Count; i++) {
-            CardCategory category = (CardCategory)EnumUtils.TryParse(typeof(CardCategory), jsonArray[i], true, null);
-            if (category != null) {
+            CardCategory category = (CardCategory)EnumUtils.TryParse(typeof(CardCategory), jsonArray[i], true, CardCategory.NO_CATEGORY);
+            if (category != CardCategory.NO_CATEGORY) {
               Categories.Add(category);
             }
+          }
+          if (Categories.Count == 0) {
+            Categories.Add(CardCategory.NO_CATEGORY);
           }
         }
       }


### PR DESCRIPTION
CardCategory cannot be null, so change the default value to NO_CATEGORY, and only add it to Categories if it is the only category in the JSON array